### PR TITLE
Fix for varlink 11 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ termcolor = "*"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-varlink = "8.1"
+varlink = "11"
 
 [build-dependencies]
-varlink_generator = "8.0"
+varlink_generator = "10.1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,6 +46,16 @@ pub fn run_server(address: &str, tally: Arc<RwLock<Tally>>) -> varlink::Result<(
         "http://wordtree.org",
         vec![Box::new(myinterface)],
     );
-    varlink::listen(service, &address, 1, 10, 0)?;
+    varlink::listen(
+        service,
+        &address,
+        &varlink::ListenConfig {
+            initial_worker_threads: 1,
+            max_worker_threads: 10,
+            idle_timeout: 0,
+            ..Default::default()
+        },
+    )?;
+
     Ok(())
 }


### PR DESCRIPTION
Upgraded varlink_generator from v8 to v10.1.0 and varlink from 8.1 to 11.

This removes the outdated chainerror v0.4.3, which causes build failures with:

error[E0119]: conflicting implementations of trait `std::error::Error` for type `&ChainError<_>`

